### PR TITLE
initial experiments on switchover to environment vars

### DIFF
--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
         # Display the notification for the user to update the main zone
         msg = "Please add the following CNAME record to your main DNS zone:\n{}"
-        cname = "{} CNAME {}".format(VALIDATION_DOMAIN, account["fulldomain"])
+        cname = "{} CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
         print(msg.format(cname))
 
     # Update the TXT record in acme-dns instance


### PR DESCRIPTION
this is my initial experiment on using env vars.

i'm calling this an experiment, because it works... but I'm not entirely sold on it.  You can view the README formatted here: https://github.com/jvanasco/acme-dns-certbot-joohoi/tree/feature-env_vars

I changed around a few things

* everything is now driven by env vars
* i moved a chunk of code into __main__, as it's only used there (and was easier to do the following...)
* i added two commands that can be called by invoking the script:

```
$ python /etc/letsencrypt/acme-dns-auth.py --version
$ python /etc/letsencrypt/acme-dns-auth.py --setup
```

`--version` will print the version of the script's compatible env vars. I added version tracking so issues with upgrading in the future can be detected and reported

`--setup` will generate a template helper to setup the environment variables

