### PR TITLE
Force usage of Python 3

### DIFF
--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 import requests


### PR DESCRIPTION
On Debian10, `python` automatically points to Python 2.

Fixes #14 as well.