### PR TITLE
Use absolute domain name in message

### DIFF
--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
         # Display the notification for the user to update the main zone
         msg = "Please add the following CNAME record to your main DNS zone:\n{}"
-        cname = "{} CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
+        cname = "{}. CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
         print(msg.format(cname))
 
     # Update the TXT record in acme-dns instance


### PR DESCRIPTION
When we tell the user which CNAME record to add, make the entry absolute
by ending it with a dot. This prevents that the user accidentally adds a
record for _acme-challenge.example.org.example.org when they copy-paste.