### PR TITLE
Fix CNAME output

### DIFF
--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
         # Display the notification for the user to update the main zone
         msg = "Please add the following CNAME record to your main DNS zone:\n{}"
-        cname = "{} IN CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
+        cname = "{}. IN CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
         print(msg.format(cname))
 
     # Update the TXT record in acme-dns instance

--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
         # Display the notification for the user to update the main zone
         msg = "Please add the following CNAME record to your main DNS zone:\n{}"
-        cname = "{} CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
+        cname = "{} IN CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
         print(msg.format(cname))
 
     # Update the TXT record in acme-dns instance


### PR DESCRIPTION
- The current CNAME output does not work its missing an "IN" string, this patch adds the "IN" string to the output.
- Added a dot to the domain name so the name of the zone does not get appended to the acme CNAME.
