### PR TITLE
Add support for mTLS

### DIFF
--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -17,7 +17,7 @@ ALLOW_FROM = []
 FORCE_REGISTER = False
 
 # Optional, mTLS region
-# NOTE: if ACMDEDNS_URL has to have SSL enabled (https://) for this to have an effect
+# NOTE: ACMDEDNS_URL must have SSL enabled (https://) for this to have an effect
 USE_MTLS = False # change to True to present client certificate
 MTLS_CERT_PATH = "/etc/letsencrypt/acmedns_mtls_client_cert.pem"
 MTLS_KEY_PATH = "/etc/letsencrypt/acmedns_mtls_client_key.pem"


### PR DESCRIPTION
I'm working on setting an acme-dns instance that I want to be as secure as possible, therefore I am wrapping joohoi/acme-dns behind a proxy to require mTLS. In order for this to work, the client script needs to offer a cert.